### PR TITLE
Typo

### DIFF
--- a/src/pages/dashboard/integrate.md
+++ b/src/pages/dashboard/integrate.md
@@ -54,7 +54,7 @@
 
     - Go to [Deepview Previews](https://dashboard.branch.io/web/deepviews) on the Branch Dashboard
     - Toggle `Enabled` for `branch_default` for `iOS` and `Android`
-    - This will make your deep links before optimally on all [Supported platforms](/pages/links/integrate/#expected-redirect-behavior)
+    - This will make your deep links perform optimally on all [Supported platforms](/pages/links/integrate/#expected-redirect-behavior)
     - Additional details about [Deepviews](/pages/web/deep-views/)
         
         ![image](/img/pages/dashboard/deepview.png)


### PR DESCRIPTION
"deep links before optimally" -> "deep links perform optimally"