### PR TITLE
[react-native] proguard patch

### DIFF
--- a/src/pages/apps/react-native.md
+++ b/src/pages/apps/react-native.md
@@ -145,6 +145,11 @@
 	        - `key_live_gdzsepIaUf7wG3dEWb3aBkmcutm0PwJa`
 	        - `key_test_edwDakKcMeWzJ3hC3aZs9kniyuaWGCTa`
 
+      - `android/app/proguard-rules.pro`
+          ```proguard
+          -dontwarn io.branch.**
+          ```
+
 - #### Initialize Branch
 
 	- Swift 3.0 `AppDelegate.swift`


### PR DESCRIPTION
This is necessary to avoid an annoying build problem. It's been added to the README.