### PR TITLE
Updated Swift call to register a content view

### DIFF
--- a/src/pages/apps/ios.md
+++ b/src/pages/apps/ios.md
@@ -456,7 +456,7 @@
     - *Swift 3*
 
         ```swift
-        buo.userCompletedAction(BNCRegisterViewEvent)
+        buo.registerView()
         ```
 
     - *Objective-C*


### PR DESCRIPTION
Ed updated the call in the docs here: https://docs.branch.io/pages/links/integrate/#universal-object

"Initialize the Branch Universal Object and call userCompletedAction with the BranchEvent.VIEW ([buo registerView] for objective-C and buo.registerView() for swift) on page load"