### PR TITLE
fix: all nav links must have trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@
 
 - #### Navigation
     
-    - Different page `click [here](/pages/apps/ios/#configure-bundle-identifier)`
+    - Different page `click [here](/pages/apps/ios/)` (must have trailing slash)
 
-    - Same page `click [here](#configure-bundle-identifier)`
+    - Different page anchor `click [here](/pages/apps/ios/#configure-bundle-identifier)`
+
+    - Same page anchor `click [here](#configure-bundle-identifier)`
 
 - #### Tips, notes, warnings etc.
 

--- a/src/pages/app-to-app/android-instant-apps.md
+++ b/src/pages/app-to-app/android-instant-apps.md
@@ -76,7 +76,7 @@ Instant Apps can be rather confusing as there are many different manifests, but 
 
 ### Configure your Branch links as Android App Links
 
-This guide presumes that you've already configured Branch for Android App Links in the past. If you haven't configured your full native app to use Branch as Android App Links, [please complete this guide](/pages/apps/universal-app-links) which will correctly configure the dashboard and manifest.
+This guide presumes that you've already configured Branch for Android App Links in the past. If you haven't configured your full native app to use Branch as Android App Links, [please complete this guide](/pages/apps/universal-app-links/) which will correctly configure the dashboard and manifest.
 
 Now, you simply need to edit the above manifest and paste in the following snippet _inside_ the desired `activity.` Then you'll need to replace the `xxxx` with your own custom subdomain which will be visible on [the Branch link settings dashboard](https://dashboard.branch.io/link-settings){:target="\_blank"} at the bottom of the page. If you're using a custom subdomain, you can find the advanced instructions in the above link regarding configuring Android App Links.
 

--- a/src/pages/dashboard/analytics.md
+++ b/src/pages/dashboard/analytics.md
@@ -118,7 +118,7 @@
     - ##### Tracking
         - Use the [Referral analytics](https://dashboard.branch.io/referrals/analytics)
         - Use the [LiveView export](https://dashboard.branch.io/liveview/link_clicks) to get data as a `.csv`
-        - Create a [Webhook](/pages/exports/webhooks) to send data to your server
+        - Create a [Webhook](/pages/exports/webhooks/) to send data to your server
 
     - ##### Querying
         - Query the events export the custom referral event that triggered the referral rule

--- a/src/pages/deep-linked-ads/branch-universal-ads.md
+++ b/src/pages/deep-linked-ads/branch-universal-ads.md
@@ -11,7 +11,7 @@ Branch Universal Ads help you drive results for web and app campaigns.
 
 ### Ad Partners
 
-Here is a list of integrated [Ad Partners](/pages/ad-networks/ad-networks-list).
+Here is a list of integrated [Ad Partners](/pages/ad-networks/ad-networks-list/).
 
 ## Setup
 

--- a/src/pages/emails/get-started.md
+++ b/src/pages/emails/get-started.md
@@ -110,22 +110,22 @@ The following are all the possible settings you can configure for deep linking w
 
 Completing your integration requires some setup that is specific to your email service provider. Please follow the documentation for your provider:
 
-- **[Amazon SES](/pages/emails/amazon-ses)**
-- **[Braze (formerly Appboy)](/pages/emails/braze)**
-- **[Blueshift](pages/emails/blueshift)**
-- **[Bronto](/pages/emails/bronto)**
-- **[Campaign Monitor](/pages/emails/campaign-monitor)**
-- **[Epsilon](/pages/emails/epsilon)**
-- **[Kahuna](/pages/emails/kahuna)**
-- **[Leanplum](/pages/emails/leanplum)**
-- **[Mailgun](/pages/emails/mailgun)**
-- **[Mailjet](/pages/emails/mailjet)**
-- **[Mandrill](/pages/emails/mandrill)**
-- **[PostUp](/pages/emails/postup)**
-- **[Responsys](/pages/emails/responsys)**
-- **[Sailthru](/pages/emails/sailthru)**
-- **[Salesforce](/pages/emails/salesforce)**
-- **[SendGrid](/pages/emails/sendgrid)**
-- **[SparkPost](/pages/emails/sparkpost)**
-- **[Vero](/pages/emails/vero)**
-- **[Zeta](/pages/emails/zeta)**
+- **[Amazon SES](/pages/emails/amazon-ses/)**
+- **[Braze (formerly Appboy)](/pages/emails/braze/)**
+- **[Blueshift](pages/emails/blueshift/)**
+- **[Bronto](/pages/emails/bronto/)**
+- **[Campaign Monitor](/pages/emails/campaign-monitor/)**
+- **[Epsilon](/pages/emails/epsilon/)**
+- **[Kahuna](/pages/emails/kahuna/)**
+- **[Leanplum](/pages/emails/leanplum/)**
+- **[Mailgun](/pages/emails/mailgun/)**
+- **[Mailjet](/pages/emails/mailjet/)**
+- **[Mandrill](/pages/emails/mandrill/)**
+- **[PostUp](/pages/emails/postup/)**
+- **[Responsys](/pages/emails/responsys/)**
+- **[Sailthru](/pages/emails/sailthru/)**
+- **[Salesforce](/pages/emails/salesforce/)**
+- **[SendGrid](/pages/emails/sendgrid/)**
+- **[SparkPost](/pages/emails/sparkpost/)**
+- **[Vero](/pages/emails/vero/)**
+- **[Zeta](/pages/emails/zeta/)**

--- a/src/pages/emails/vero.md
+++ b/src/pages/emails/vero.md
@@ -11,7 +11,7 @@ Contact your Branch Account Manager or [accounts@branch.io](mailto:accounts@bran
 
 ### Choose your email service provider
 
-Navigate to the [Deep Linked Email](https://dashboard.branch.io/email){:target="\_blank"} section of the Branch dashboard. Select SendGrid or Mailgun as your email service provider and click **Get Started**. If you do not know which ESP to select, please contact your Vero account manager. Then, follow the [SendGrid](/pages/emails/sendgrid) or [Mailgun](/pages/emails/mailgun) setup steps.
+Navigate to the [Deep Linked Email](https://dashboard.branch.io/email){:target="\_blank"} section of the Branch dashboard. Select SendGrid or Mailgun as your email service provider and click **Get Started**. If you do not know which ESP to select, please contact your Vero account manager. Then, follow the [SendGrid](/pages/emails/sendgrid/) or [Mailgun](/pages/emails/mailgun/) setup steps.
 
 ![image](/img/pages/email/choose-esp.png)
 

--- a/src/pages/exports/api-v3.md
+++ b/src/pages/exports/api-v3.md
@@ -10,7 +10,7 @@ Branch’s new Data Export API for [People-Based Attribution](/pages/dashboard/p
 !!! note "Data Feeds is a premium solution"
     The Data Export API is included in Branch’s [Data Feeds](/pages/exports/data-feeds/) offering, which can be purchased according to Branch’s [pricing schedule](https://branch.io/pricing/){:target="\_blank"}, and is available at no additional charge to customers who are on MAU plans for [Journeys](https://branch.io/journeys/){:target="\_blank"}, [Deep Linked Email](https://branch.io/email/){:target="\_blank"}, or [Universal Ads](https://branch.io/attribution/){:target="\_blank"}. Without Data Feeds, you can still export Branch data in CSV form directly from the Branch dashboard via [Sources](https://dashboard.branch.io/sources){:target="\_blank"} or [CSV Exports](https://dashboard.branch.io/data-import-export/csv-exports){:target="\_blank"}.
 
-    **If you are looking for the legacy Data Export API**, please see [these docs](/pages/exports/api).
+    **If you are looking for the legacy Data Export API**, please see [these docs](/pages/exports/api/).
 
 ## Setup
 
@@ -62,7 +62,7 @@ The response payload will be in JSON format and for each export it will have an 
 }
 ```
 
-All exports via Data Feeds are powered by Branch's [People-Based Attribution](/pages/dashboard/people-based-attribution). For an exhaustive list of events included in these exports and more detailed definitions of each event, please see the [Event Ontology Data Schema](/pages/exports/event_ontology_data_schema/).
+All exports via Data Feeds are powered by Branch's [People-Based Attribution](/pages/dashboard/people-based-attribution/). For an exhaustive list of events included in these exports and more detailed definitions of each event, please see the [Event Ontology Data Schema](/pages/exports/event_ontology_data_schema/).
 
 !!! tip
     A full day's files will be available on our S3 bucket at that location to download around 8:00am UTC. It will return a blank array from s3 for any empty files until the UTC day is over and the data has been transfered to s3, therefore it is recommended you schedule any ETLs to fetch the data for the previous day around 8:00am UTC.

--- a/src/pages/exports/data-feeds.md
+++ b/src/pages/exports/data-feeds.md
@@ -6,7 +6,7 @@ Data Feeds is Branch’s premium suite of tools for exporting data. If you want 
 - [**Webhooks:**](/pages/exports/ua-webhooks/) fully customizable templated webhooks that send Branch data to the endpoint of your choice in near-real time.
 - [**Data Export API:**](/pages/exports/api-v3/) an API that will allow you to pull CSV files containing all of your Branch data from the past week.
 
-All exports via Data Feeds are powered by Branch's [People-Based Attribution](/pages/dashboard/people-based-attribution). For an exhaustive list of events included in these exports and more detailed definitions of each event, please see the [Event Ontology Data Schema](/pages/exports/event_ontology_data_schema/).
+All exports via Data Feeds are powered by Branch's [People-Based Attribution](/pages/dashboard/people-based-attribution/). For an exhaustive list of events included in these exports and more detailed definitions of each event, please see the [Event Ontology Data Schema](/pages/exports/event_ontology_data_schema/).
 
 !!! note "Data Feeds is a premium solution"
     Data Feeds can be purchased according to Branch’s [pricing schedule](https://branch.io/pricing/){:target="\_blank"}, and is available at no additional charge to customers who are on MAU plans for [Journeys](https://branch.io/journeys/){:target="\_blank"}, [Deep Linked Email](https://branch.io/email/){:target="\_blank"}, or [Universal Ads](https://branch.io/attribution/){:target="\_blank"}. Without Data Feeds, you can still export Branch data in CSV form directly from the Branch dashboard via [Sources](https://dashboard.branch.io/sources){:target="\_blank"} or [CSV Exports](https://dashboard.branch.io/data-import-export/csv-exports){:target="\_blank"}.

--- a/src/pages/exports/ua-webhooks.md
+++ b/src/pages/exports/ua-webhooks.md
@@ -2,7 +2,7 @@
 
 Branch’s new webhook system for People-Based Attribution allows you to export install and down-funnel event data as it occurs. You can import this data into your internal systems for analysis. You simply need to specify a URL for the POST or GET requests.
 
-If you are looking for postback integrations for ad networks, please visit our [Universal Ads documentation](/pages/deep-linked-ads/universal-ads). For pre-configured integrations into popular analytics tools, please visit our [Data Integrations documentation](/pages/integrations/amplitude/).
+If you are looking for postback integrations for ad networks, please visit our [Universal Ads documentation](/pages/deep-linked-ads/universal-ads/). For pre-configured integrations into popular analytics tools, please visit our [Data Integrations documentation](/pages/integrations/amplitude/).
 
 The webhook system is highly customizable. You can register to only receive notifications for specific events, as well as specific subsections of events, filtered by link data, user data or event properties.
 
@@ -11,7 +11,7 @@ Our new webhook infrastructure supports for all Branch events. The data is forma
 !!! note "Data Feeds is a premium solution"
     The Webhooks are included in Branch’s [Data Feeds](/pages/exports/data-feeds/) offering, which can be purchased according to Branch’s [pricing schedule](https://branch.io/pricing/){:target="\_blank"}, and is available at no additional charge to customers who are on MAU plans for [Journeys](https://branch.io/journeys/){:target="\_blank"}, [Deep Linked Email](https://branch.io/email/){:target="\_blank"}, or [Universal Ads](https://branch.io/attribution/){:target="\_blank"}. Without Data Feeds, you can still export Branch data in CSV form directly from the Branch dashboard via [Sources](https://dashboard.branch.io/sources){:target="\_blank"} or [CSV Exports](https://dashboard.branch.io/data-import-export/csv-exports){:target="\_blank"}.
 
-    **If you are looking for legacy webhooks**, please see [these docs](/pages/exports/webhooks).
+    **If you are looking for legacy webhooks**, please see [these docs](/pages/exports/webhooks/).
 
 ## Setup
 


### PR DESCRIPTION
This will prevent https://branchmetrics.github.io/docs redirects. Read #documentation for more information. Sample regex to find all broken links: `(\[.+\])(\(\/pages)([a-zA-z-\/]*)\)`

cc @chang-brian. Make sure this requirement is filled before all merges into master.