### PR TITLE
Query API docs in Data Feeds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,8 @@ pages:
         - Tune: pages/integrations/tune.md
       - Data Export API: pages/exports/api-v3.md
       - Webhooks: pages/exports/ua-webhooks.md
+      - Query API: pages/exports/query-api.md
+      - Query Recipe Book: pages/exports/query-recipe-book.md
   - Branch Matching Overview: pages/resources/matching.md
   - Validation Tools: pages/resources/validation-tools.md
   - Case Studies and Infographics: pages/resources/case-studies.md
@@ -219,5 +221,3 @@ pages:
     - Event Ontology: pages/exports/event_ontology_data_schema.md
     - New Data Integrations: pages/integrations/faq.md
     - Ad Networks List: pages/ad-networks/ad-networks-list.md
-    - Query API: pages/exports/query-api.md
-    - Query Recipe Book: pages/exports/query-recipe-book.md

--- a/src/pages/exports/data-feeds.md
+++ b/src/pages/exports/data-feeds.md
@@ -5,6 +5,7 @@ Data Feeds is Branch’s premium suite of tools for exporting data. If you want 
 - [**Data Integrations:**](/pages/integrations/data-integrations/) pre-built integrations with other analytics services and marketing tools. Just input your credentials and Branch will automatically send your data to any of our integrated partners.
 - [**Webhooks:**](/pages/exports/ua-webhooks/) fully customizable templated webhooks that send Branch data to the endpoint of your choice in near-real time.
 - [**Data Export API:**](/pages/exports/api-v3/) an API that will allow you to pull CSV files containing all of your Branch data from the past week.
+- [**Query API:**](/pages/exports/query-api/) an API for querying for any of the pre-aggregated Branch event data that you can see on the dashboard.
 
 All exports via Data Feeds are powered by Branch's [People-Based Attribution](/pages/dashboard/people-based-attribution/). For an exhaustive list of events included in these exports and more detailed definitions of each event, please see the [Event Ontology Data Schema](/pages/exports/event_ontology_data_schema/).
 


### PR DESCRIPTION
Two changes: 

1. Link to Query API docs in Data Feeds "Get Started" page
2. Un-hide Query API & Query Recipe Book docs, add to Data Feeds sub-menu of docs

**Note that this change should not be made until the beginning of next week, when we'll be adding Query API to the dashboard as part of Data Feeds**