### PR TITLE
Removed .addMetadataKey from BUO code

### DIFF
--- a/src/pages/viral/content-sharing.md
+++ b/src/pages/viral/content-sharing.md
@@ -49,9 +49,8 @@ Create a `BranchUniversalObject` containing details about the content that is be
     branchUniversalObject.title = "Meet Mr. Squiggles"
     branchUniversalObject.contentDescription = "Your friend Josh has invited you to meet his awesome monster, Mr. Squiggles!"
     branchUniversalObject.imageUrl = "https://example.com/monster-pic-12345.png"
-    branchUniversalObject.addMetadataKey("userId", value: "12345")
-    branchUniversalObject.addMetadataKey("userName", value: "Josh")
-    branchUniversalObject.addMetadataKey("monsterName", value: "Mr. Squiggles")
+    branchUniversalObject.contentMetadata.customMetadata = ["custom":"123"]
+    branchUniversalObject.contentMetadata.customMetadata = ["anything":"everything"]
     ```
 
 - *Android*


### PR DESCRIPTION
buo.addMetadataKey is deprecated according to Xcode, so I replaced it with buo.contentMetadata.customMetadata = ["":""] based on the Branch framework notes