### PR TITLE
Fixed Branch object syntax for metadata code

### DIFF
--- a/src/pages/apps/react-native.md
+++ b/src/pages/apps/react-native.md
@@ -782,13 +782,13 @@
         - *Swift 3 & 4*
 
             ```swift
-            RNBranchModule.setRequestMetadataKey("insert_user_id", "value")
+            RNBranch.setRequestMetadataKey("insert_user_id", "value")
             ```
 
         - *Android*
 
             ```java
-            RNBranch.setRequestMetadata("userID", "value");
+            RNBranchModule.setRequestMetadata("userID", "value");
             ```
 
 


### PR DESCRIPTION
Probably my fault, but I swapped the Branch objects for Swift & Java to their appropriate names