### PR TITLE
Replace deprecated openUrl Objective-C method

### DIFF
--- a/src/pages/apps/react-native.md
+++ b/src/pages/apps/react-native.md
@@ -273,8 +273,8 @@
                 //...
             }
 
-            - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-                if (![RNBranch.branch application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
+            - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+                if (![RNBranch.branch application:app openURL:url options:options]) {
                     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
                 }
                 return YES;


### PR DESCRIPTION
application:openURL:sourceApplication:annotation: was deprecated after iOS 9, in favor of  application:openURL:options:. https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623073-application?language=objc