### PR TITLE
Fix Facebook Campaign Advert Format Support Table

### DIFF
--- a/src/pages/deep-linked-ads/facebook-app-install-ads.md
+++ b/src/pages/deep-linked-ads/facebook-app-install-ads.md
@@ -21,8 +21,8 @@ Consideration | App Installs | App Only: Install
 #### Facebook Campaign Advert Format Support Table
 
 Facebook Campaign Type | Photo | Video | Carousel | Slideshow | Collection | Dynamic | Canvas
---- | --- | --- | --- | --- | --- | ---
-App Installs | ✔︎ | ✔︎ | ✔︎ | ✔︎ |  |  | ✔︎
+--- | --- | --- | --- | --- | --- | --- | ---
+App Installs | ✔︎ | ✔︎ | ✔︎ | ✔︎ | - | - | ✔︎
 
 {! ingredients/deep-linked-ads/link-to-facebook-ads-overview.md !}
 


### PR DESCRIPTION
Added  "| ---" at the end of the 2nd line of the table, to fix the table.