### PR TITLE
Correct casing in react-native.md

### DIFF
--- a/src/pages/apps/react-native.md
+++ b/src/pages/apps/react-native.md
@@ -137,7 +137,7 @@
 
                 ![image](/img/pages/apps/ios-package.png)
 
-        - Configure info.pList
+        - Configure Info.plist
 
             - Add [Branch Dashboard](https://dashboard.branch.io/account-settings/app) values
 


### PR DESCRIPTION
Apple uses a different casing than the one currently used in the docs. See [Info.plist docs](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html) for reference.