### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
     - Write in the viewpoint of the `user's wants`, not what Branch wants
 
-    - Keep is simple (KISS) (`1 -> 2 -> 3`)
+    - Keep it simple (KISS) (`1 -> 2 -> 3`)
 
     - Don't repeat yourself (DRY) (`this can be found here`)
 


### PR DESCRIPTION
Explanation of the KISS principle had a typo.