### PR TITLE
Correct casing in ios.md

### DIFF
--- a/src/pages/apps/ios.md
+++ b/src/pages/apps/ios.md
@@ -32,7 +32,7 @@
 
         ![image](/img/pages/apps/ios-package.png)
 
-- ### Configure info.pList
+- ### Configure Info.plist
 
     - Add [Branch Dashboard](https://dashboard.branch.io/account-settings/app) values
 


### PR DESCRIPTION
Apple uses a different casing than the one currently used in the docs. See [Info.plist docs](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html) for reference.

Similar to PR #753.