### PR TITLE
DOCS-285 Removed .getFirstReferringParams()

### DIFF
--- a/src/pages/apps/android.md
+++ b/src/pages/apps/android.md
@@ -504,11 +504,8 @@
             }
         }, this.intent.data, this)
 
-        // latest
+        // Retrieve link data outside of the initialization callback (must happen after callback executes)
         val sessionParams = Branch.getInstance().latestReferringParams
-
-        // first
-        val installParams = Branch.getInstance().firstReferringParams
         ```
 
 - ### Navigate to content

--- a/src/pages/apps/android.md
+++ b/src/pages/apps/android.md
@@ -486,11 +486,8 @@
             }
         }, this.getIntent().getData(), this);
 
-        // latest
+        // Retrieve link data outside of the initialization callback (must happen after callback executes)
         JSONObject sessionParams = Branch.getInstance().getLatestReferringParams();
-
-        // first
-        JSONObject installParams = Branch.getInstance().getFirstReferringParams();
         ```
 
     - *Kotlin*


### PR DESCRIPTION
Per @derrickstaten , we no longer support first referring params (https://branch.slack.com/archives/C0R24ELKW/p1531424806000449)