### PR TITLE
DOCS-280 Update early closed function call brackets

### DIFF
--- a/src/pages/apps/react-native.md
+++ b/src/pages/apps/react-native.md
@@ -392,7 +392,7 @@
     let branchUniversalObject = await branch.createBranchUniversalObject('canonicalIdentifier', {
       locallyIndex: true,
       title: 'Cool Content!',
-      contentDescription: 'Cool Content Description'}),
+      contentDescription: 'Cool Content Description',
       contentMetadata: {
         ratingAverage: 4.2,
         customMetadata: {


### PR DESCRIPTION
The declaration of `branchUniversalObject` had a **parenthesis (and a bracket)** closing the object earlier than it had to, so I just removed the extra parenthesis (and bracket):

```js
// only canonicalIdentifier is required
let branchUniversalObject = await branch.createBranchUniversalObject('canonicalIdentifier', {
  locallyIndex: true,
  title: 'Cool Content!',
  contentDescription: 'Cool Content Description'}),
  contentMetadata: {
    ratingAverage: 4.2,
    customMetadata: {
      prop1: 'test',
      prop2: 'abc'
    }
  }
})
```

To:

```js
// only canonicalIdentifier is required
let branchUniversalObject = await branch.createBranchUniversalObject('canonicalIdentifier', {
  locallyIndex: true,
  title: 'Cool Content!',
  contentDescription: 'Cool Content Description',
  contentMetadata: {
    ratingAverage: 4.2,
    customMetadata: {
      prop1: 'test',
      prop2: 'abc'
    }
  }
})
```