### PR TITLE
DOCS-314: Fix conflict caused by DocSearch upgrade

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -282,6 +282,13 @@ body.modal {
 .algolia-autocomplete .ds-dropdown-menu, .algolia-autocomplete .ds-dropdown-menu:before {
   box-shadow: none;
 }
+.algolia-docsearch-suggestion {
+  font-size: 1em !important;
+  margin-right: 0;
+}
+.algolia-docsearch-suggestion:hover {
+  opacity: 1 !important;
+}
 .algolia-docsearch-suggestion--category-header {
   display: none !important;
 }
@@ -383,7 +390,7 @@ body.modal {
 /* BRANCH STYLING */
 /* ////////////////////////////// */
 /* primary */
-.md-header, .modal-content a:not(.algolia-docsearch-footer--logo), .modal-content button {
+.md-header, .modal-content a:not(.algolia-docsearch-footer--logo):not(.algolia-docsearch-suggestion), .modal-content button {
   background-color: #004875 !important;
 }
 @media only screen and (max-width: 76.1875em) {


### PR DESCRIPTION
Algolia upgraded the DocSearch library, which changed the wrapper element from `<div>` to `<a>`. That caused some CSS conflicts.