### PR TITLE
text changes on ios docs

### DIFF
--- a/src/pages/apps/ios.md
+++ b/src/pages/apps/ios.md
@@ -626,7 +626,7 @@
 
     - Allows Branch to track Apple Search Ads deep linking analytics
 
-    - Analytics from Apple's API have been slow which will make our analytics lower. Additionally, Apple's API does not send us all the data of an ad every time which will make ads tracked by us to show a generic campaign sometimes.
+    - Analytics from Apple's API have been slow which will make our analytics slower. Additionally, Apple's API does not send us all the data of an ad every time which will make ads tracked by us to show a generic campaign sometimes.
 
     - Add before `initSession` [Initialize Branch](#initialize-branch)
 


### PR DESCRIPTION
Not sure if "lower" is actually a typo or the intended text (I thought "slower" would make more sense in this context).