### PR TITLE
Add note about Twitter URI redirect case

### DIFF
--- a/src/pages/links/integrate.md
+++ b/src/pages/links/integrate.md
@@ -35,7 +35,7 @@
             | Instagram Profile | Fallback | *Able to force app open | App |
             | Instagram Browser | App | | App |
             | Instagram Stories | Fallback | *Able to force app open | App |
-            | Twitter Feed | Fallback | *Able to force app open. Links with `$ios_url` or `$fallback_url` redirect fallbacks require [web SDK 2.48.0+](https://github.com/BranchMetrics/web-branch-deep-linking/releases/tag/v2.48.0) init for the app | App |
+            | Twitter Feed | Fallback | *Able to force app open. Links with `$ios_url` or `$fallback_url` redirect fallbacks require [web SDK 2.48.0+](https://github.com/BranchMetrics/web-branch-deep-linking/releases/tag/v2.48.0) init on the website | App |
             | Twitter Browser | App | | App |
             | Snap messages | App | | App | 
             | Snap stories | Fallback | deep linking blocked on iOS | App | 

--- a/src/pages/links/integrate.md
+++ b/src/pages/links/integrate.md
@@ -35,7 +35,7 @@
             | Instagram Profile | Fallback | *Able to force app open | App |
             | Instagram Browser | App | | App |
             | Instagram Stories | Fallback | *Able to force app open | App |
-            | Twitter Feed | Fallback | *Able to force app open. Links with redirect fallback require [web SDK 2.48.0+](https://github.com/BranchMetrics/web-branch-deep-linking/releases/tag/v2.48.0) | App |
+            | Twitter Feed | Fallback | *Able to force app open. Links with `$ios_url` or `$fallback_url` redirect fallbacks require [web SDK 2.48.0+](https://github.com/BranchMetrics/web-branch-deep-linking/releases/tag/v2.48.0) init for the app | App |
             | Twitter Browser | App | | App |
             | Snap messages | App | | App | 
             | Snap stories | Fallback | deep linking blocked on iOS | App | 

--- a/src/pages/links/integrate.md
+++ b/src/pages/links/integrate.md
@@ -35,7 +35,7 @@
             | Instagram Profile | Fallback | *Able to force app open | App |
             | Instagram Browser | App | | App |
             | Instagram Stories | Fallback | *Able to force app open | App |
-            | Twitter Feed | Fallback | *Able to force app open | App |
+            | Twitter Feed | Fallback | *Able to force app open. Links with redirect fallback require [web SDK 2.48.0+](https://github.com/BranchMetrics/web-branch-deep-linking/releases/tag/v2.48.0) | App |
             | Twitter Browser | App | | App |
             | Snap messages | App | | App | 
             | Snap stories | Fallback | deep linking blocked on iOS | App | 


### PR DESCRIPTION
Tons of context here: https://branch.atlassian.net/browse/INTENG-4362

TL;DR you need the web SDK to deep link if your link has an $ios_url or $fallback_url

I didn't want to add too much info about this, but just call out the caveat.