### PR TITLE
fix: variable name for resultIntent

### DIFF
--- a/src/pages/apps/android.md
+++ b/src/pages/apps/android.md
@@ -773,8 +773,8 @@
 
         ```java
         Intent resultIntent = new Intent(this, TargetClass.class);
-        intent.putExtra("branch","http://xxxx.app.link/testlink");
-        intent.putExtra("branch_force_new_session",true);
+        resultIntent.putExtra("branch","http://xxxx.app.link/testlink");
+        resultIntent.putExtra("branch_force_new_session",true);
         PendingIntent resultPendingIntent =  PendingIntent.getActivity(this, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         ```
 
@@ -782,9 +782,9 @@
 
         ```java
         val resultIntent = Intent(this, TargetClass::class.java)
-        intent.putExtra("branch", "http://xxxx.app.link/testlink")
+        resultIntent.putExtra("branch", "http://xxxx.app.link/testlink")
         val resultPendingIntent = PendingIntent.getActivity(this, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT)
-        intent.putExtra("branch_force_new_session", true)
+        resultIntent.putExtra("branch_force_new_session", true)
         ```
 
 - ### Handle links in your own app


### PR DESCRIPTION
The variable used in the https://docs.branch.io/pages/apps/android/#handle-push-notification is not in sync. Minor fix.