### PR TITLE
Swift 4.2: Use correct UIApplicationDelegate protocol for universal links

### DIFF
--- a/src/pages/apps/ios.md
+++ b/src/pages/apps/ios.md
@@ -109,7 +109,7 @@
           return true
         }
 
-        func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {
+        func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
           // handler for Universal Links
           Branch.getInstance().continue(userActivity)
           return true


### PR DESCRIPTION
The current Swift 4.2 handler for universal links does not implement the correct 
 application(_:continue:restorationHandler:) UIApplicationDelegate protocol causing universal links to fail and creating a warning in XCode:

```
UIApplicationDelegate: 
//...
@available(iOS 8.0, *)
optional public func application(_ application: UIApplication,
                         continue userActivity: NSUserActivity,
                            restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool
//...
```

Proposed change: 'restorationHandler' should expect a 'UIUserActivityRestoring' instead of 'Any'.

Source: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application