### PR TITLE
Removed reference to toggle to send all events

### DIFF
--- a/pages/deep-linked-ads/partnerize-mobile-tracking.md
+++ b/pages/deep-linked-ads/partnerize-mobile-tracking.md
@@ -32,8 +32,6 @@ This guide will walk you through how to setup your campaigns with **[Partnerize]
 
 {! ingredients/deep-linked-ads/add-more-postbacks-short.md !}
 
-{! ingredients/deep-linked-ads/all-events-toggle.md !}
-
 {! ingredients/deep-linked-ads/whitelist-ip.md !}
 
 {! ingredients/deep-linked-ads/edit-postbacks.md !}


### PR DESCRIPTION
Per @IGonebnyy 's note in slack (https://branch.slack.com/archives/C0R24ELKW/p1552434760213700?thread_ts=1552398093.209200&cid=C0R24ELKW), Partnerize requested that we disable this functionality for their integration