### PR TITLE
Update Bulk URL create limit

### DIFF
--- a/pages/apps/deep-linking-api.md
+++ b/pages/apps/deep-linking-api.md
@@ -114,7 +114,7 @@
         | branch_key | `string` | From your [Branch Settings Dashboard](https://dashboard.branch.io/settings) | √
         | ... | ... | Parameters from [Configuring Links](/links/integrate/) |
 
-    - Bulk link creator is limited to `1000` links at a time
+    - Bulk link creator is limited to a JSON payload size of 250KB at a time. 
 
 - ### Link read
 


### PR DESCRIPTION
Changing up the limit from number of links to JSON payload size. Got confirmation from engineering in the following ticket - https://branch.atlassian.net/browse/INTENG-4987