### PR TITLE
Fix broken Link Settings link

### DIFF
--- a/pages/deep-linked-ads/google-ads-troubleshooting.md
+++ b/pages/deep-linked-ads/google-ads-troubleshooting.md
@@ -67,7 +67,7 @@ creative_id | ~creative_id
 
 **A:** While we should always expect around a 5% discrepancy due to time zone differences and the like, if you are seeing significant discrepancies, it could be an indication of a broader problem.
 
-The first thing to do is to make sure you have enabled the `Use Ad Partner Attribution Windows` setting for Google Ads. Go to [Link Settings](https://branch.dashboard.branch.io/ads/partner-management/a_google_adwords?tab=attribution_windows), and navigate down to the Attribution Windows section. Here, you should set the attribution window for `click to install`, `click to session start`, and `click to conversion event` to be 30, 90, and 90 days respectively. This aligns with Google's default attribution windows, but if you'd like to make them shorter, feel free.
+The first thing to do is to make sure you have enabled the `Use Ad Partner Attribution Windows` setting for Google Ads. Go to [Link Settings](https://dashboard.branch.io/ads/partner-management/a_google_adwords?tab=attribution_windows), and navigate down to the Attribution Windows section. Here, you should set the attribution window for `click to install`, `click to session start`, and `click to conversion event` to be 30, 90, and 90 days respectively. This aligns with Google's default attribution windows, but if you'd like to make them shorter, feel free.
 
 Another source of discrepancies is the fact that attribution is based upon *click* time in Google Ads, whereas it is based upon *install* time in the Branch dashboard. This isn't a discrepancy per se, but will sometimes show different numbers in the two dashboards.
 


### PR DESCRIPTION
Removing Branch-SSO-specific "branch." from https://branch.dashboard.branch.io/ads/partner-management/a_google_adwords?tab=attribution_windows so clickers don't get taken to our SSO login page. 