### PR TITLE
integrations@branch.io -> support@branch.io

### DIFF
--- a/pages/exports/ua-webhooks.md
+++ b/pages/exports/ua-webhooks.md
@@ -283,7 +283,7 @@ Here is a list of blocked expressions:
 
 ### Authenticating webhook events
 
-To request authentication headers for your webhooks, please contact `integrations@branch.io`.
+To request authentication headers for your webhooks, please contact `support@branch.io`.
 
 ## Support
 


### PR DESCRIPTION
I think we've deprecated intergations@ and moved everyone to support@. Feel free to close if I'm totally wrong.