### PR TITLE
Mark play-services-ads as required framework

### DIFF
--- a/pages/apps/android.md
+++ b/pages/apps/android.md
@@ -55,13 +55,16 @@
             implementation 'com.android.support:appcompat-v7:25.2.0'
             implementation 'com.android.support:design:25.2.0'
 
-            // required
+            // required for all Android apps
             implementation 'io.branch.sdk.android:library:3.+'
+            
+            // required if your app is in the Google Play Store
             implementation 'com.google.android.gms:play-services-appindexing:9.+' // App indexing
+            implementation 'com.google.android.gms:play-services-ads:9+' // GAID matching
             
             // optional
             implementation 'com.android.support:customtabs:23.3.0' // Chrome Tab matching
-            implementation 'com.google.android.gms:play-services-ads:9+' // GAID matching
+            
 
 
             testImplementation 'junit:junit:4.12'

--- a/pages/apps/android.md
+++ b/pages/apps/android.md
@@ -57,11 +57,12 @@
 
             // required
             implementation 'io.branch.sdk.android:library:3.+'
-
+            implementation 'com.google.android.gms:play-services-appindexing:9.+' // App indexing
+            
             // optional
             implementation 'com.android.support:customtabs:23.3.0' // Chrome Tab matching
             implementation 'com.google.android.gms:play-services-ads:9+' // GAID matching
-            implementation 'com.google.android.gms:play-services-appindexing:9.+' // App indexing
+
 
             testImplementation 'junit:junit:4.12'
         }


### PR DESCRIPTION
Edit to make play-services-ads as a required framework. This is a must for accurate attribution and matching.