### PR TITLE
Added language for customer_event_alias

### DIFF
--- a/pages/apps/cordova-phonegap-ionic.md
+++ b/pages/apps/cordova-phonegap-ionic.md
@@ -503,6 +503,7 @@
         Branch.getStandardEvents().then(function success(res) {
             var event = res.STANDARD_EVENT_ADD_TO_CART;
             var metadata = {
+                customerEventAlias: "alias name for event",
                 transactionID: '1234455',
                 currency: 'USD',
                 revenue: 1.5,

--- a/pages/apps/cordova-phonegap-ionic.md
+++ b/pages/apps/cordova-phonegap-ionic.md
@@ -503,7 +503,7 @@
         Branch.getStandardEvents().then(function success(res) {
             var event = res.STANDARD_EVENT_ADD_TO_CART;
             var metadata = {
-                customerEventAlias: "alias name for event",
+                customerEventAlias: 'alias name for event',
                 transactionID: '1234455',
                 currency: 'USD',
                 revenue: 1.5,


### PR DESCRIPTION
Per this PR (https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/commit/709fe768961705caec86bf53de3229a6bb828940#diff-e5f4e9578411c44b725c9981de993125), it looks like we can add a "customerEventAlias" key to the metadata object to set an alias