### PR TITLE
fix "info" tag at top of page

### DIFF
--- a/pages/apps/ios.md
+++ b/pages/apps/ios.md
@@ -1,4 +1,4 @@
- !!! info "Current SDK Version 0.31.3"
+!!! info "Current SDK Version 0.31.3"
     Please see the [iOS Version History](/version-histories/ios-version-history) to view change log.
 
 ## Integrate Branch


### PR DESCRIPTION
The live page currently shows "!!! info" in plain text at the top of the page. I believe this is because of the spacing in front of the "!!!"