### PR TITLE
Undo some accidental side-effects of title script

### DIFF
--- a/pages/apps/ios.md
+++ b/pages/apps/ios.md
@@ -1207,8 +1207,7 @@ title: iOS SDK
 
         ```swift
         lp.addControlParam("$email_subject", withValue: "Your Awesome Deal")
-        lp.addControlParam("$email_html_header", withValue: "<style>your awesome CSS</style>
-Or Dear Friend,")
+        lp.addControlParam("$email_html_header", withValue: "<style>your awesome CSS</style>\nOr Dear Friend,")
         lp.addControlParam("$email_html_footer", withValue: "Thanks!")
         lp.addControlParam("$email_html_link_text", withValue: "Tap here")
         ```
@@ -1217,8 +1216,7 @@ Or Dear Friend,")
 
         ```objc
         [lp addControlParam:@"$email_subject" withValue:@"This one weird trick."];
-        [lp addControlParam:@"$email_html_header" withValue:@"<style>your awesome CSS</style>
-Or Dear Friend,"];
+        [lp addControlParam:@"$email_html_header" withValue:@"<style>your awesome CSS</style>\nOr Dear Friend,"];
         [lp addControlParam:@"$email_html_footer" withValue:@"Thanks!"];
         [lp addControlParam:@"$email_html_link_text" withValue:@"Tap here"];
         ```

--- a/pages/apps/windows-csharp.md
+++ b/pages/apps/windows-csharp.md
@@ -441,18 +441,18 @@ This class is need for customize "Link sharing"
 
  1. Build solution
  2. Copy COM Library from
-**..\BranchWindowsSdk\DLLs\Debugranch_debug_0.1.0.tlb** or
-**..\BranchWindowsSdk\DLLs\Releaseranch_0.1.0.tlb** to
+**..\BranchWindowsSdk\DLLs\Debug\branch_debug_0.1.0.tlb** or
+**..\BranchWindowsSdk\DLLs\Release\branch_0.1.0.tlb** to
 **..\Your Project Folder\Your Project Name\Debug** or
 **..\Your Project Folder\Your Project Name\Release**
  3. Import library
 ```cpp
-#import "..\Your Project Name\Debugranch_debug_0.1.0.tlb"
+#import "..\Your Project Name\Debug\branch_debug_0.1.0.tlb"
 using namespace branch_debug_0.1.0;
 ```
 or
 ```cpp
-#import "..\Your Project Name\Debugranch_0.1.0.tlb"
+#import "..\Your Project Name\Debug\branch_0.1.0.tlb"
 using namespace branch_0.1.0;
 ```
  4. Include ```<thread>```

--- a/pages/apps/xamarin.md
+++ b/pages/apps/xamarin.md
@@ -300,8 +300,7 @@ title: Xamarin
                     void LogMessage(string message)
                     {
                         Console.WriteLine(message);
-                        logString += DateTime.Now.ToLongTimeString() + "> " + message + "
-";
+                        logString += DateTime.Now.ToLongTimeString() + "> " + message + "\n";
                     }
 
                     #endregion
@@ -350,8 +349,7 @@ title: Xamarin
                     void LogMessage(string message)
                     {
                         Console.WriteLine(message);
-                        logString += DateTime.Now.ToLongTimeString() + "> " + message + "
-";
+                        logString += DateTime.Now.ToLongTimeString() + "> " + message + "\n";
                     }
 
                     #endregion

--- a/pages/dashboard/agency-view.md
+++ b/pages/dashboard/agency-view.md
@@ -1,9 +1,6 @@
 ---
 title: Agency View
 ---
----
-title: Viewing Agency/Partner Settings
----
 !!! warning "Invite Required"
 	For any Agency to access a customer Branch account, an invitation from an Admin user at the [Organization](/dashboard/organization-view/#adding-an-agency) or [App](/dashboard/app-view/#adding-an-agency) entity level of access is required. All Agency Admins on the agency account will receive an invitation email, and any of those Agency Admins can accept the invitation on behalf of their agency.
 

--- a/pages/deep-linked-ads/ad-networks-list.md
+++ b/pages/deep-linked-ads/ad-networks-list.md
@@ -1,9 +1,6 @@
 ---
 title: Ad Partners List
 ---
----
-title: Universal Ad Partners
----
 Interested in becoming a Universal Ads Partner? Just fill out this form: **[Partner's Profile](https://branch.app.link/tech-partner-signup){:target="\_blank"}**
 
 **Partner Website** | **Branch Integration Guide**

--- a/pages/deep-linked-ads/facebook-traffic-conversion-ads.md
+++ b/pages/deep-linked-ads/facebook-traffic-conversion-ads.md
@@ -1,12 +1,6 @@
 ---
 title: Facebook Traffic and Conversion Ads
 ---
----
-title: Facebook Traffic and Conversion Ads
-description: An overview page of using Branch in your Facebook Traffic and Conversion ad campaigns.
-path: tree/master/src/deep-linked-ads
-source: facebook-traffic-conversion-ads.md
----
 # Facebook Traffic and Conversion Ads
 
 ## Overview

--- a/pages/deep-linking/routing.md
+++ b/pages/deep-linking/routing.md
@@ -393,9 +393,7 @@ protected void onResume() {
         try {
             String autoDeeplinkedValue = Branch.getInstance().getLatestReferringParams().getString("product_picture");
             launch_mode_txt.setText("Launched by Branch on auto deep linking!"
-                    + "
-
-" + autoDeeplinkedValue);
+                    + "\n\n" + autoDeeplinkedValue);
         } catch (JSONException e) {
             e.printStackTrace();
         }

--- a/pages/emails/email-partners-list.md
+++ b/pages/emails/email-partners-list.md
@@ -1,9 +1,6 @@
 ---
 title: Email Partners List
 ---
----
-title: Universal Email Partners
----
 Interested in becoming a Email Partner? Just fill out this form: **[Partner's Profile](https://branch.app.link/tech-partner-signup){:target="\_blank"}**
 
 Logo | Partner

--- a/pages/integrations/data-integrations-list.md
+++ b/pages/integrations/data-integrations-list.md
@@ -1,7 +1,4 @@
 ---
-title: Data Integrations
----
----
 title: Data Integration Partners List
 ---
 Data Integrations provide an easy way to automatically send Branch data to your other analytics services and marketing tools using pre-formatted webhooks. For most integrations, configuration just requires you to input your credentials and hit “Enable”.

--- a/pages/ko/branch-ios.md
+++ b/pages/ko/branch-ios.md
@@ -1,7 +1,6 @@
 ---
 title: Branch 연동 가이드 - iOS
 ---
-
 !!! warning "iOS 11.2+ 에서 Universal Link의 액션이 일치하지 않은 이슈에 대한 설명"
     일반적으로 Universal Link 가 정상적으로 작동하려면 사용자가 앱을 설치한 이후 iOS에서 해당 앱의 AASA 파일을 다운로드합니다. 하지만 iOS 11.2+ 로 업데이트되면서 Branch 에서는 AASA 파일이 사용자의 디바이스에 확실하게 다운로드되지 않을 때가 있는 것을 발견했습니다. 그 결과로, iOS 11.2+ 에서 Universal Link 를 클릭할 때 항상 앱이 실행되는 것은 아닙니다. 그러므로 광고주께서는 Branch 링크 생성 때 forced uri redirect mode 를 설정하여 URI 스키마로 앱을 실행할 수 있습니다. 해당 이슈에 대한 상세내용은 Apple Bug report 를 참고하기 바랍니다.
 
@@ -889,8 +888,7 @@ title: Branch 연동 가이드 - iOS
 
         ```swift
         lp.addControlParam("$email_subject", withValue: "Your Awesome Deal")
-        lp.addControlParam("$email_html_header", withValue: "<style>your awesome CSS</style>
-Or Dear Friend,")
+        lp.addControlParam("$email_html_header", withValue: "<style>your awesome CSS</style>\nOr Dear Friend,")
         lp.addControlParam("$email_html_footer", withValue: "Thanks!")
         lp.addControlParam("$email_html_link_text", withValue: "Tap here")
         ```
@@ -899,8 +897,7 @@ Or Dear Friend,")
 
         ```objc
         [lp addControlParam:@"$email_subject" withValue:@"This one weird trick."];
-        [lp addControlParam:@"$email_html_header" withValue:@"<style>your awesome CSS</style>
-Or Dear Friend,"];
+        [lp addControlParam:@"$email_html_header" withValue:@"<style>your awesome CSS</style>\nOr Dear Friend,"];
         [lp addControlParam:@"$email_html_footer" withValue:@"Thanks!"];
         [lp addControlParam:@"$email_html_link_text" withValue:@"Tap here"];
         ```

--- a/pages/ko/deep-link-routing.md
+++ b/pages/ko/deep-link-routing.md
@@ -396,9 +396,7 @@ protected void onResume() {
         try {
             String autoDeeplinkedValue = Branch.getInstance().getLatestReferringParams().getString("product_picture");
             launch_mode_txt.setText("Launched by Branch on auto deep linking!"
-                    + "
-
-" + autoDeeplinkedValue);
+                    + "\n\n" + autoDeeplinkedValue);
         } catch (JSONException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
@gfletcher-branch the title script also borked some code snippets (e.g., https://docs.branch.io/apps/xamarin/) because it turned `\n` into an actual linebreak. This reverts that.

@dwestgate FYI